### PR TITLE
Add dependency on generated file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(UGpoint_cloud boost_signals)
 target_link_libraries(UGpoint_cloud ${catkin_LIBRARIES})      
 
 add_executable(UGpublish_images src/utils/publish_images.cpp)
+add_dependencies(UGpublish_images ug_stereomatcher_generate_messages_cpp)
 target_link_libraries(UGpublish_images ${catkin_LIBRARIES})
 
 # ######################### GPUmatcher


### PR DESCRIPTION
Without this, first time compilation fails when not finding generated file `ug_stereomatcher/CamerasSync.h` [here](https://github.com/gerac83/ug_stereomatcher/blob/master/src/utils/publish_images.cpp#L21).
