### PR TITLE
updates, correct colour conversion and change resolution of point cloud

### DIFF
--- a/src/pointcloud/getPointCloud.cpp
+++ b/src/pointcloud/getPointCloud.cpp
@@ -139,7 +139,6 @@ public:
     }
     //Functions
     void getImages(const sensor_msgs::ImageConstPtr& imL, const sensor_msgs::ImageConstPtr& imR, const sensor_msgs::CameraInfoConstPtr& msgL, const sensor_msgs::CameraInfoConstPtr& msgR);
-
     void getDisparities(const stereo_msgs::DisparityImageConstPtr& dispX_msg, const stereo_msgs::DisparityImageConstPtr& dispY_msg); // non Fovea 
     void getFDisparities(const ug_stereomatcher::foveatedstackConstPtr dispX_msg, const ug_stereomatcher::foveatedstackConstPtr dispY_msg); // Fovea
 
@@ -222,12 +221,12 @@ void CdynamicCalibration::getImages(const sensor_msgs::ImageConstPtr& imL, const
     ROS_INFO("Getting images and camera info...");
     try
     {
-        cv_ptrL = cv_bridge::toCvCopy(imL, enc::RGB8);
-        cv_ptrR = cv_bridge::toCvCopy(imR, enc::RGB8);
+        cv_ptrL = cv_bridge::toCvCopy(imL, enc::BGR8);
+        cv_ptrR = cv_bridge::toCvCopy(imR, enc::BGR8);
     }
     catch (cv_bridge::Exception& e)
     {
-        //ROS_ERROR("Could not convert from '%s' to 'rgb8'.", imL->encoding.c_str());
+        //ROS_ERROR("Could not convert from '%s' to 'bgr8'.", imL->encoding.c_str());
         return;
     }
 
@@ -1182,7 +1181,7 @@ int main(int argc, char* argv[])
     ros::init( argc, argv, "RH_dynamicCalibration_node" );
     CdynamicCalibration rU_;
 
-    rU_.sampling =10; // for the non fovea version change this to 5
+    rU_.sampling =5; // for the non fovea version change this to 5
 
     if((argc == 2) && (strcmp(argv[1], "-s") == 0))
     {


### PR DESCRIPTION
opencv/simplecv default colour format is BGR, (http://wiki.ros.org/cv_bridge/Tutorials/UsingCvBridgeToConvertBetweenROSImagesAndOpenCVImages section 0.1) so image format should be BGR when converted from ROS to opencv images.
